### PR TITLE
Fix null identifier error on media post save

### DIFF
--- a/Media.java
+++ b/Media.java
@@ -1,0 +1,56 @@
+package com.example.entity;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "media")
+public class Media {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+    
+    @Column(name = "public_id", nullable = false, unique = true, updatable = false)
+    private String publicId;
+
+    @Column(name = "secure_url", nullable = false, unique = true, updatable = false)
+    private String secureUrl;
+    
+    @Column(name = "file_type")
+    private String fileType;
+    
+    @Column(name = "file_size")
+    private Long fileSize;
+    
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private LocalDateTime createdDate;
+    
+    // One-to-One relationship with MediaPost (optional back reference)
+    @OneToOne(mappedBy = "media")
+    @ToString.Exclude
+    private MediaPost mediaPost;
+    
+    @PrePersist
+    protected void onCreate() {
+        createdDate = ZonedDateTime.now(ZoneId.of("Z")).toLocalDateTime();
+    }
+}

--- a/MediaPost.java
+++ b/MediaPost.java
@@ -1,0 +1,68 @@
+package com.example.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "media_post")
+public class MediaPost {
+    
+    @Id
+    private Integer id;
+    
+    // One-to-One relationship with Media using @MapsId
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id", referencedColumnName = "id")
+    @ToString.Exclude
+    private Media media;
+    
+    // Many-to-One relationship with Post
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    @ToString.Exclude
+    private Post post;
+    
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+    
+    @Column(name = "is_thumbnail", nullable = false)
+    private Boolean isThumbnail = false;
+    
+    @Column(name = "caption")
+    private String caption;
+    
+    @PrePersist
+    protected void onCreate() {
+        updateThumbnailStatus();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updateThumbnailStatus();
+    }
+    
+    private void updateThumbnailStatus() {
+        if (displayOrder != null && displayOrder <= 3) {
+            isThumbnail = true;
+        } else {
+            isThumbnail = false;
+        }
+    }
+}

--- a/MediaPostRepository.java
+++ b/MediaPostRepository.java
@@ -1,0 +1,31 @@
+package com.example.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.entity.MediaPost;
+import com.example.entity.Post;
+
+@Repository
+public interface MediaPostRepository extends JpaRepository<MediaPost, Integer> {
+    
+    List<MediaPost> findByPostId(Integer postId);
+    
+    List<MediaPost> findByPost(Post post);
+    
+    List<MediaPost> findByPostOrderByDisplayOrder(Post post);
+    
+    List<MediaPost> findByIsThumbnailTrue();
+    
+    @Query("SELECT mp FROM MediaPost mp WHERE mp.post.id = :postId ORDER BY mp.displayOrder ASC")
+    List<MediaPost> findByPostIdOrderByDisplayOrder(@Param("postId") Integer postId);
+    
+    @Query("SELECT mp FROM MediaPost mp WHERE mp.post.id = :postId AND mp.isThumbnail = true")
+    List<MediaPost> findThumbnailsByPostId(@Param("postId") Integer postId);
+    
+    void deleteByPost(Post post);
+}

--- a/MediaRepository.java
+++ b/MediaRepository.java
@@ -1,0 +1,27 @@
+package com.example.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.entity.Media;
+
+@Repository
+public interface MediaRepository extends JpaRepository<Media, Integer> {
+    
+    Optional<Media> findByPublicId(String publicId);
+    
+    Optional<Media> findBySecureUrl(String secureUrl);
+    
+    List<Media> findByFileType(String fileType);
+    
+    @Query("SELECT m FROM Media m WHERE m.mediaPost IS NULL")
+    List<Media> findUnusedMedia();
+    
+    @Query("SELECT m FROM Media m WHERE m.fileSize > :size")
+    List<Media> findByFileSizeGreaterThan(@Param("size") Long size);
+}

--- a/Post.java
+++ b/Post.java
@@ -1,0 +1,109 @@
+package com.example.entity;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "post")
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+    
+    // One-to-Many relationship with MediaPost
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<MediaPost> mediaPosts = new ArrayList<>();
+    
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @ToString.Exclude
+    private User user;	
+    
+    @Column(name = "like_count", nullable = false)
+    @NotNull(message = "Like count cannot be null")
+    @Min(0)
+    private Integer likeCount = 0;
+
+    @Column(name = "view_count", nullable = false)
+    @NotNull(message = "View count cannot be null")
+    @Min(0)
+    private Integer viewCount = 0;
+
+    @Column(name = "comment_count", nullable = false)
+    @NotNull(message = "Comment count cannot be null")
+    @Min(0)
+    private Integer commentCount = 0;
+    
+    @Column(name = "status", nullable = false)
+    @NotNull(message = "Status cannot be null")
+    private Integer status = 0; // 0=draft, 1=published, 2=archived, 3=deleted
+    
+    @Column(name = "lat")
+    private Double latitude;
+    
+    @Column(name = "lon")
+    private Double longitude;
+    
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private LocalDateTime createdDate;
+    
+    @Column(name = "updated_date")
+    private LocalDateTime updatedDate;
+    
+    @PrePersist
+    protected void onCreate() {
+        createdDate = ZonedDateTime.now(ZoneId.of("Z")).toLocalDateTime();
+        updatedDate = createdDate;
+        
+        if (status == null) {
+            status = 0;
+        }
+        
+        if (mediaPosts == null) {
+            mediaPosts = new ArrayList<>();
+        }
+    }
+    
+    // Utility method to add MediaPost
+    public void addMediaPost(MediaPost mediaPost) {
+        mediaPosts.add(mediaPost);
+        mediaPost.setPost(this);
+    }
+    
+    // Utility method to remove MediaPost
+    public void removeMediaPost(MediaPost mediaPost) {
+        mediaPosts.remove(mediaPost);
+        mediaPost.setPost(null);
+    }
+}

--- a/PostRepository.java
+++ b/PostRepository.java
@@ -1,0 +1,41 @@
+package com.example.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.entity.Post;
+import com.example.entity.User;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Integer> {
+    
+    List<Post> findByUserId(Integer userId);
+    
+    List<Post> findByUser(User user);
+    
+    List<Post> findByStatus(Integer status);
+    
+    Page<Post> findByStatusOrderByCreatedDateDesc(Integer status, Pageable pageable);
+    
+    @Query("SELECT p FROM Post p WHERE p.user.id = :userId AND p.status = :status ORDER BY p.createdDate DESC")
+    List<Post> findByUserIdAndStatus(@Param("userId") Integer userId, @Param("status") Integer status);
+    
+    @Query("SELECT p FROM Post p WHERE p.content LIKE %:keyword% AND p.status = 1")
+    List<Post> findByContentContainingAndPublished(@Param("keyword") String keyword);
+    
+    @Query("SELECT p FROM Post p JOIN p.mediaPosts mp WHERE mp.media.id = :mediaId")
+    Post findByMediaId(@Param("mediaId") Integer mediaId);
+    
+    @Query("SELECT p FROM Post p WHERE p.createdDate BETWEEN :startDate AND :endDate ORDER BY p.createdDate DESC")
+    List<Post> findByCreatedDateBetween(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+    
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.user.id = :userId AND p.status = 1")
+    Long countPublishedPostsByUser(@Param("userId") Integer userId);
+}

--- a/PostService.java
+++ b/PostService.java
@@ -1,0 +1,254 @@
+package com.example.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.entity.Media;
+import com.example.entity.MediaPost;
+import com.example.entity.Post;
+import com.example.entity.User;
+import com.example.repository.MediaPostRepository;
+import com.example.repository.MediaRepository;
+import com.example.repository.PostRepository;
+import com.example.repository.UserRepository;
+
+@Service
+@Transactional
+public class PostService {
+
+    @Autowired
+    private PostRepository postRepository;
+    
+    @Autowired
+    private MediaRepository mediaRepository;
+    
+    @Autowired
+    private MediaPostRepository mediaPostRepository;
+    
+    @Autowired
+    private UserRepository userRepository;
+
+    /**
+     * Creates a post with media - CORRECT WAY to handle @MapsId relationships
+     */
+    public Post createPostWithMedia(String content, Integer userId, List<CreateMediaRequest> mediaRequests) {
+        // 1. Get the user
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        // 2. Create and save Media entities FIRST
+        List<Media> savedMediaList = new ArrayList<>();
+        for (CreateMediaRequest mediaRequest : mediaRequests) {
+            Media media = new Media();
+            media.setPublicId(mediaRequest.getPublicId());
+            media.setSecureUrl(mediaRequest.getSecureUrl());
+            media.setFileType(mediaRequest.getFileType());
+            media.setFileSize(mediaRequest.getFileSize());
+            
+            // Save Media first to get the generated ID
+            Media savedMedia = mediaRepository.save(media);
+            savedMediaList.add(savedMedia);
+        }
+        
+        // 3. Create Post
+        Post post = new Post();
+        post.setContent(content);
+        post.setUser(user);
+        post.setStatus(1); // Published
+        
+        // Save Post to get the generated ID
+        Post savedPost = postRepository.save(post);
+        
+        // 4. Create MediaPost entities linking Media and Post
+        List<MediaPost> mediaPosts = new ArrayList<>();
+        for (int i = 0; i < savedMediaList.size(); i++) {
+            Media savedMedia = savedMediaList.get(i);
+            CreateMediaRequest mediaRequest = mediaRequests.get(i);
+            
+            MediaPost mediaPost = new MediaPost();
+            // IMPORTANT: Set the ID explicitly for @MapsId
+            mediaPost.setId(savedMedia.getId());
+            mediaPost.setMedia(savedMedia);
+            mediaPost.setPost(savedPost);
+            mediaPost.setDisplayOrder(i + 1);
+            mediaPost.setCaption(mediaRequest.getCaption());
+            
+            // Save MediaPost
+            MediaPost savedMediaPost = mediaPostRepository.save(mediaPost);
+            mediaPosts.add(savedMediaPost);
+        }
+        
+        // 5. Update Post's collection (optional, for return value completeness)
+        savedPost.setMediaPosts(mediaPosts);
+        
+        return savedPost;
+    }
+
+    /**
+     * Alternative approach - Save from Post side with proper setup
+     */
+    public Post createPostWithMediaCascade(String content, Integer userId, List<CreateMediaRequest> mediaRequests) {
+        // 1. Get the user
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("User not found"));
+        
+        // 2. Create Post
+        Post post = new Post();
+        post.setContent(content);
+        post.setUser(user);
+        post.setStatus(1);
+        
+        // 3. Create Media and MediaPost entities
+        List<MediaPost> mediaPosts = new ArrayList<>();
+        for (int i = 0; i < mediaRequests.size(); i++) {
+            CreateMediaRequest mediaRequest = mediaRequests.get(i);
+            
+            // Create and save Media first
+            Media media = new Media();
+            media.setPublicId(mediaRequest.getPublicId());
+            media.setSecureUrl(mediaRequest.getSecureUrl());
+            media.setFileType(mediaRequest.getFileType());
+            media.setFileSize(mediaRequest.getFileSize());
+            Media savedMedia = mediaRepository.save(media);
+            
+            // Create MediaPost
+            MediaPost mediaPost = new MediaPost();
+            mediaPost.setId(savedMedia.getId()); // Set ID for @MapsId
+            mediaPost.setMedia(savedMedia);
+            mediaPost.setDisplayOrder(i + 1);
+            mediaPost.setCaption(mediaRequest.getCaption());
+            
+            // Set up bidirectional relationship
+            mediaPost.setPost(post);
+            mediaPosts.add(mediaPost);
+        }
+        
+        // 4. Set MediaPosts to Post and save (will cascade)
+        post.setMediaPosts(mediaPosts);
+        return postRepository.save(post);
+    }
+
+    /**
+     * Add media to existing post
+     */
+    public Post addMediaToPost(Integer postId, CreateMediaRequest mediaRequest) {
+        // 1. Get existing post
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new RuntimeException("Post not found"));
+        
+        // 2. Create and save Media
+        Media media = new Media();
+        media.setPublicId(mediaRequest.getPublicId());
+        media.setSecureUrl(mediaRequest.getSecureUrl());
+        media.setFileType(mediaRequest.getFileType());
+        media.setFileSize(mediaRequest.getFileSize());
+        Media savedMedia = mediaRepository.save(media);
+        
+        // 3. Create MediaPost
+        MediaPost mediaPost = new MediaPost();
+        mediaPost.setId(savedMedia.getId());
+        mediaPost.setMedia(savedMedia);
+        mediaPost.setPost(post);
+        
+        // Set display order (next in sequence)
+        int nextOrder = post.getMediaPosts().size() + 1;
+        mediaPost.setDisplayOrder(nextOrder);
+        mediaPost.setCaption(mediaRequest.getCaption());
+        
+        // 4. Save MediaPost and update Post
+        mediaPostRepository.save(mediaPost);
+        post.getMediaPosts().add(mediaPost);
+        
+        return post;
+    }
+
+    /**
+     * Update post media order
+     */
+    public Post updateMediaOrder(Integer postId, List<MediaOrderRequest> orderRequests) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new RuntimeException("Post not found"));
+        
+        for (MediaOrderRequest orderRequest : orderRequests) {
+            MediaPost mediaPost = mediaPostRepository.findById(orderRequest.getMediaId())
+                .orElseThrow(() -> new RuntimeException("MediaPost not found"));
+            
+            mediaPost.setDisplayOrder(orderRequest.getNewOrder());
+            mediaPostRepository.save(mediaPost);
+        }
+        
+        return postRepository.findById(postId).orElseThrow();
+    }
+
+    /**
+     * Remove media from post
+     */
+    public Post removeMediaFromPost(Integer postId, Integer mediaId) {
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new RuntimeException("Post not found"));
+        
+        MediaPost mediaPost = mediaPostRepository.findById(mediaId)
+            .orElseThrow(() -> new RuntimeException("MediaPost not found"));
+        
+        // Remove from Post's collection
+        post.getMediaPosts().remove(mediaPost);
+        
+        // Delete MediaPost (this will orphan the Media)
+        mediaPostRepository.delete(mediaPost);
+        
+        return post;
+    }
+
+    // DTO Classes
+    public static class CreateMediaRequest {
+        private String publicId;
+        private String secureUrl;
+        private String fileType;
+        private Long fileSize;
+        private String caption;
+        
+        // Constructors, getters, setters
+        public CreateMediaRequest() {}
+        
+        public CreateMediaRequest(String publicId, String secureUrl, String fileType, Long fileSize, String caption) {
+            this.publicId = publicId;
+            this.secureUrl = secureUrl;
+            this.fileType = fileType;
+            this.fileSize = fileSize;
+            this.caption = caption;
+        }
+        
+        // Getters and setters
+        public String getPublicId() { return publicId; }
+        public void setPublicId(String publicId) { this.publicId = publicId; }
+        public String getSecureUrl() { return secureUrl; }
+        public void setSecureUrl(String secureUrl) { this.secureUrl = secureUrl; }
+        public String getFileType() { return fileType; }
+        public void setFileType(String fileType) { this.fileType = fileType; }
+        public Long getFileSize() { return fileSize; }
+        public void setFileSize(Long fileSize) { this.fileSize = fileSize; }
+        public String getCaption() { return caption; }
+        public void setCaption(String caption) { this.caption = caption; }
+    }
+    
+    public static class MediaOrderRequest {
+        private Integer mediaId;
+        private Integer newOrder;
+        
+        public MediaOrderRequest() {}
+        
+        public MediaOrderRequest(Integer mediaId, Integer newOrder) {
+            this.mediaId = mediaId;
+            this.newOrder = newOrder;
+        }
+        
+        public Integer getMediaId() { return mediaId; }
+        public void setMediaId(Integer mediaId) { this.mediaId = mediaId; }
+        public Integer getNewOrder() { return newOrder; }
+        public void setNewOrder(Integer newOrder) { this.newOrder = newOrder; }
+    }
+}

--- a/User.java
+++ b/User.java
@@ -1,0 +1,55 @@
+package com.example.entity;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+    
+    @Column(name = "full_name")
+    private String fullName;
+    
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private LocalDateTime createdDate;
+    
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<Post> posts = new ArrayList<>();
+    
+    @PrePersist
+    protected void onCreate() {
+        createdDate = ZonedDateTime.now(ZoneId.of("Z")).toLocalDateTime();
+    }
+}

--- a/UserRepository.java
+++ b/UserRepository.java
@@ -1,0 +1,25 @@
+package com.example.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.example.entity.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+    
+    Optional<User> findByUsername(String username);
+    
+    Optional<User> findByEmail(String email);
+    
+    boolean existsByUsername(String username);
+    
+    boolean existsByEmail(String email);
+    
+    @Query("SELECT u FROM User u WHERE u.username = :username OR u.email = :email")
+    Optional<User> findByUsernameOrEmail(@Param("username") String username, @Param("email") String email);
+}


### PR DESCRIPTION
Implements a robust JPA structure for Media (1-1) MediaPost (n-1) Post relationships.

The previous setup encountered a "null identifier" error for `MediaPost` when attempting to persist from the `Post` side. This was due to `MediaPost` using `@MapsId`, which means its primary key is derived from the `Media` entity. The fix ensures that `Media` is persisted first, and its generated ID is explicitly assigned to `MediaPost` before `MediaPost` is persisted, resolving the dependency issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-43dd6998-037f-41ab-a9bb-a52fefe9ae92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43dd6998-037f-41ab-a9bb-a52fefe9ae92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

